### PR TITLE
chore: bump version to 2.6.2 and update Google Drive scope to DRIVE_APPDATA

### DIFF
--- a/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
+++ b/android/src/main/java/org/rncloudfs/RNCloudFsModule.java
@@ -392,7 +392,8 @@ public class RNCloudFsModule extends ReactContextBaseJavaModule implements Googl
         GoogleSignInOptions signInOptions =
                 new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                         .requestEmail()
-                        .requestScopes(new Scope(DriveScopes.DRIVE_FILE))
+                        // .requestScopes(new Scope(DriveScopes.DRIVE_FILE))
+                        .requestScopes(new Scope(DriveScopes.DRIVE_APPDATA))
                         .build();
         GoogleSignInClient client = GoogleSignIn.getClient(this.reactContext, signInOptions);
 
@@ -425,7 +426,8 @@ public class RNCloudFsModule extends ReactContextBaseJavaModule implements Googl
         GoogleSignInOptions signInOptions =
                 new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                         .requestEmail()
-                        .requestScopes(new Scope(DriveScopes.DRIVE_FILE))
+                        // .requestScopes(new Scope(DriveScopes.DRIVE_FILE))
+                        .requestScopes(new Scope(DriveScopes.DRIVE_APPDATA))
                         .build();
         GoogleSignInClient client = GoogleSignIn.getClient(this.reactContext, signInOptions);
         mDriveServiceHelper = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/react-native-cloud-fs",
-  "version": "2.6.1",
+  "version": "2.6.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Drive permission scope for authentication updated to request application-specific (appdata) storage access only.

* **Chores**
  * Package version bumped to 2.6.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->